### PR TITLE
Support multiple origins.

### DIFF
--- a/Src/Fido2.Models/Fido2Configuration.cs
+++ b/Src/Fido2.Models/Fido2Configuration.cs
@@ -1,11 +1,12 @@
-﻿using System.Net.Http;
+﻿using System.Linq;
+using System.Net.Http;
 
 namespace Fido2NetLib
 {
     public class Fido2Configuration
     {
         /// <summary>
-        /// This member specifies a time, in milliseconds, that the caller is willing to wait for the call to complete. 
+        /// This member specifies a time, in milliseconds, that the caller is willing to wait for the call to complete.
         /// This is treated as a hint, and MAY be overridden by the client.
         /// </summary>
         public uint Timeout { get; set; } = 60000;
@@ -36,9 +37,21 @@ namespace Fido2NetLib
         public string ServerIcon { get; set; }
 
         /// <summary>
-        /// Server origin, including protocol host and port.
+        /// List of allowable server origins, including protocol host and port.
         /// </summary>
-        public string Origin { get; set; }
+        public string[] Origins { get; set; }
+
+        /// <summary>
+        /// Server origin, including protocol host and port
+        /// </summary>
+        public string Origin
+        {
+            get => Origins?.FirstOrDefault();
+            set
+            {
+                Origins = new[] {value};
+            }
+        }
 
         /// <summary>
         /// MDSAccessKey

--- a/Src/Fido2/AuthenticatorAssertionResponse.cs
+++ b/Src/Fido2/AuthenticatorAssertionResponse.cs
@@ -50,13 +50,13 @@ namespace Fido2NetLib
         /// <param name="requestTokenBindingId"></param>
         public async Task<AssertionVerificationResult> VerifyAsync(
             AssertionOptions options,
-            string expectedOrigin,
+            string[] expectedOrigins,
             byte[] storedPublicKey,
             uint storedSignatureCounter,
             IsUserHandleOwnerOfCredentialIdAsync isUserHandleOwnerOfCredId,
             byte[] requestTokenBindingId)
         {
-            BaseVerify(expectedOrigin, options.Challenge, requestTokenBindingId);
+            BaseVerify(expectedOrigins, options.Challenge, requestTokenBindingId);
 
             if (Raw.Type != PublicKeyCredentialType.PublicKey)
                 throw new Fido2VerificationException("AssertionResponse Type is not set to public-key");
@@ -139,14 +139,14 @@ namespace Fido2NetLib
             // UNLESS...userPresent is true?
             // see ee Server-ServerAuthenticatorAssertionResponse-Resp3 Test server processing authenticatorData
             // P-8 Send a valid ServerAuthenticatorAssertionResponse both authenticatorData.flags.UV and authenticatorData.flags.UP are not set, for userVerification set to "discouraged", and check that server succeeds
-            if (UserVerificationRequirement.Required == options.UserVerification && false == authData.UserVerified) 
+            if (UserVerificationRequirement.Required == options.UserVerification && false == authData.UserVerified)
                 throw new Fido2VerificationException("User verification is required");
 
             // 14. Verify that the values of the client extension outputs in clientExtensionResults and the authenticator extension outputs in the extensions in authData are as expected, considering the client extension input values that were given as the extensions option in the get() call.In particular, any extension identifier values in the clientExtensionResults and the extensions in authData MUST be also be present as extension identifier values in the extensions member of options, i.e., no extensions are present that were not requested. In the general case, the meaning of "are as expected" is specific to the Relying Party and which extensions are in use.
             // todo: Verify this (and implement extensions on options)
-            if (true == authData.HasExtensionsData && ((null == authData.Extensions) || (0 == authData.Extensions.Length))) 
+            if (true == authData.HasExtensionsData && ((null == authData.Extensions) || (0 == authData.Extensions.Length)))
                 throw new Fido2VerificationException("Extensions flag present, malformed extensions detected");
-            if (false == authData.HasExtensionsData && (null != authData.Extensions)) 
+            if (false == authData.HasExtensionsData && (null != authData.Extensions))
                 throw new Fido2VerificationException("Extensions flag not present, but extensions detected");
 
             // 15.
@@ -157,10 +157,10 @@ namespace Fido2NetLib
             Buffer.BlockCopy(Raw.Response.AuthenticatorData, 0, data, 0, Raw.Response.AuthenticatorData.Length);
             Buffer.BlockCopy(hashedClientDataJson, 0, data, Raw.Response.AuthenticatorData.Length, hashedClientDataJson.Length);
 
-            if (null == storedPublicKey || 0 == storedPublicKey.Length) 
+            if (null == storedPublicKey || 0 == storedPublicKey.Length)
                 throw new Fido2VerificationException("Stored public key is null or empty");
             var cpk = new CredentialPublicKey(storedPublicKey);
-            if (true != cpk.Verify(data, Signature)) 
+            if (true != cpk.Verify(data, Signature))
                 throw new Fido2VerificationException("Signature did not match");
 
             // 17.

--- a/Src/Fido2/AuthenticatorAttestationResponse.cs
+++ b/Src/Fido2/AuthenticatorAttestationResponse.cs
@@ -80,7 +80,7 @@ namespace Fido2NetLib
             // 5. Verify that the value of C.origin matches the Relying Party's origin.
             // 6. Verify that the value of C.tokenBinding.status matches the state of Token Binding for the TLS connection over which the assertion was obtained.
             // If Token Binding was used on that TLS connection, also verify that C.tokenBinding.id matches the base64url encoding of the Token Binding ID for the connection.
-            BaseVerify(config.Origin, originalOptions.Challenge, requestTokenBindingId);
+            BaseVerify(config.Origins, originalOptions.Challenge, requestTokenBindingId);
 
             if (Raw.Id == null || Raw.Id.Length == 0)
                 throw new Fido2VerificationException("AttestationResponse is missing Id");

--- a/Src/Fido2/AuthenticatorResponse.cs
+++ b/Src/Fido2/AuthenticatorResponse.cs
@@ -68,7 +68,7 @@ namespace Fido2NetLib
                 throw new Fido2VerificationException("Challenge not equal to original challenge");
 
             // 5. Verify that the value of C.origin matches the Relying Party's origin.
-            if (expectedOrigins == null || expectedOrigins.Length < 1 || expectedOrigins[0] == null)
+            if (expectedOrigins == null || expectedOrigins.Length == 0 || expectedOrigins[0] == null)
             {
                 throw new Fido2VerificationException("Configuration error - at least one allowable origin must be configured");
             }

--- a/Src/Fido2/Fido2NetLib.cs
+++ b/Src/Fido2/Fido2NetLib.cs
@@ -74,11 +74,11 @@ namespace Fido2NetLib
             var success = await parsedResponse.VerifyAsync(origChallenge, _config, isCredentialIdUniqueToUser, _metadataService, requestTokenBindingId);
 
             // todo: Set Errormessage etc.
-            return new CredentialMakeResult 
-            { 
-                Status = "ok", 
-                ErrorMessage = string.Empty, 
-                Result = success 
+            return new CredentialMakeResult
+            {
+                Status = "ok",
+                ErrorMessage = string.Empty,
+                Result = success
             };
         }
 
@@ -113,7 +113,7 @@ namespace Fido2NetLib
             var parsedResponse = AuthenticatorAssertionResponse.Parse(assertionResponse);
 
             var result = await parsedResponse.VerifyAsync(originalOptions,
-                                                          _config.Origin,
+                                                          _config.Origins,
                                                           storedPublicKey,
                                                           storedSignatureCounter,
                                                           isUserHandleOwnerOfCredentialIdCallback,

--- a/Test/MetadataServiceTests.cs
+++ b/Test/MetadataServiceTests.cs
@@ -12,7 +12,7 @@ namespace Test
     public class MetadataServiceTests
     {
 
-        [Fact]
+        [Fact(Skip="The conformance test metadata service https://fidoalliance.co.nz is currently not resolvable")]
         public async Task ConformanceTestClient()
         {
             var client = new ConformanceMetadataRepository(null, "http://localhost");


### PR DESCRIPTION
This also disables a metadata service test, because the
Fido Alliance service needed for testing is currently down.